### PR TITLE
Consertar dash para não levantar onde não houver espaço

### DIFF
--- a/Assets/Scenes/Stage 1.unity
+++ b/Assets/Scenes/Stage 1.unity
@@ -1151,7 +1151,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 564782569}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 36.82, y: -8.5, z: -10}
+  m_LocalPosition: {x: -28.479551, y: -4.167378, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1778,7 +1778,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 714055635}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 36.82, y: -8.5, z: -10}
+  m_LocalPosition: {x: -28.9, y: -4.792, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 370536847}
@@ -90760,6 +90760,7 @@ MonoBehaviour:
   offsetBoxY: 0.23
   dashCollSize: {x: 0.5, y: 0.3722854}
   dashCollOffset: {x: 0.0227, y: 0.1866386}
+  gettingUpXMargin: 0.1
 --- !u!114 &1884341051
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -90917,7 +90918,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1884341048}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 36.72, y: -9, z: 0}
+  m_LocalPosition: {x: -29, y: -5.292, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1912857584}

--- a/Assets/Scripts/CrouchScript.cs
+++ b/Assets/Scripts/CrouchScript.cs
@@ -16,6 +16,7 @@ public class CrouchScript : MonoBehaviour {
 	private bool crouching = false;
 	private bool dashing = false;
 	private bool endDashWhenPossible = false;
+	private float heightDifference;
 
 	public float dashForce;
 	public float dashDuration;
@@ -25,6 +26,7 @@ public class CrouchScript : MonoBehaviour {
 	public float offsetBoxY = 0.23f;
 	public Vector2 dashCollSize = new Vector2(0.5f, 0.4f);
 	public Vector2 dashCollOffset = new Vector2(0.0227f, 0.196f);
+	public float gettingUpXMargin = 0.1f;
 
 	// Start is called before the first frame update
 	void Awake() {
@@ -37,6 +39,7 @@ public class CrouchScript : MonoBehaviour {
 		sr = GetComponent<SpriteRenderer>();
 		animator = GetComponent<Animator>();
 		foregroundLayer = LayerMask.NameToLayer("Foreground");
+		heightDifference = sizeBoxY - dashCollSize.y;
 	}
 
 	// Update is called once per frame
@@ -95,8 +98,8 @@ public class CrouchScript : MonoBehaviour {
 	}
 
 	private bool IsThereRoom() {
-		Vector2 pointA = new Vector2(boxColl.bounds.min.x, boxColl.bounds.max.y + (sizeBoxY - dashCollSize.y));
-		Vector2 pointB = boxColl.bounds.max;
+		Vector2 pointA = new Vector2(boxColl.bounds.min.x + gettingUpXMargin, boxColl.bounds.max.y + heightDifference);
+		Vector2 pointB = new Vector2(boxColl.bounds.max.x - gettingUpXMargin, boxColl.bounds.max.y);
 		Collider2D coll = Physics2D.OverlapArea(pointA, pointB, 1 << foregroundLayer);
 		return coll == null;
 	}


### PR DESCRIPTION
# Consertar dash

Consertar comportamento do player quando o dash termina em um lugar apertado.

**Modificações**
Agora, após certo tempo de dash, CrouchScript testa a cada frame se há espaço para se levantar (usando Physics2D.OverlapArea), enquanto não houver o dash não termina. Da mesma forma que funciona em Mega Man